### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # docker/Dockerfile
-FROM node:18-alpine
+FROM node:20-alpine
 
 ARG N8N_VERSION=1.108.2
 ENV N8N_VERSION=${N8N_VERSION}


### PR DESCRIPTION
Change the version of Docker for this reason : 1f0eba3a943 us-docker.pkg.dev/n8n-ads-spend/n8n-repo/n8n:933873ab "docker-entrypoint.s…" 51 seconds ago Exited (1) 50 seconds ago n8n-test Your Node.js version 18.20.8 is currently not supported by n8n. Please use a Node.js version that satisfies the following version range: >=20.19 <= 24.x